### PR TITLE
feat(smd): adding snippets for elif and else blocks.

### DIFF
--- a/syntaxes/smd/snippets.json
+++ b/syntaxes/smd/snippets.json
@@ -65,6 +65,16 @@
     "prefix": ["::: if"],
     "body": ["::: if ${1:expression}", "", "$0", "", ":::"]
   },
+  "Elif Block": {      
+    "description": "Only show block content if the preceeding 'if' conditions are false and its own condition is true.",
+    "prefix": ["::: elif"],
+    "body": ["::: elif ${1:expression}", "", "$0", "", ":::"]
+  },
+  "Else Block": {
+    "description": "Only show block content if none of the preceeding conditions are true.",
+    "prefix": ["::: else"],
+    "body": ["::: else", "", "$0", "", ":::"]
+  },
   "For Block": {
     "description": "Repeat block content for each value of a variable in an expression.",
     "prefix": ["::: for"],


### PR DESCRIPTION
**Details**

This PR is adding `elif` and `else` snippets to the extension.

When a user types `::: elif` this snippet will appear, if they press enter or select it the described text will be filled in.
<img width="757" alt="Screenshot 2024-04-18 at 3 46 48 PM" src="https://github.com/stencila/vscode-extension/assets/103614788/01e16af7-7a7b-4d12-ae4c-afb446e2611b">

When a user types `::: else` this snippet will appear, if they press enter or select it the described text will be filled in.
<img width="750" alt="Screenshot 2024-04-18 at 3 46 59 PM" src="https://github.com/stencila/vscode-extension/assets/103614788/5255ca40-78b5-4249-a053-6ce592c7c83c">
