### PR TITLE
fix(config): added extension id, publisher and changed default theme …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "stencila",
+  "id": "stencila.extension.editor",
+  "publisher": "stencila",
   "displayName": "Stencila",
   "description": "Programmable, reproducible, interactive documents",
   "version": "0.0.1",
@@ -61,7 +63,7 @@
     ],
     "themes": [
       {
-        "id": "Stencila Light",
+        "id": "StencilaLight",
         "label": "Stencila light",
         "uiTheme": "vs",
         "path": "./themes/stencila-light-color-theme.json"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ export function activate(context: vscode.ExtensionContext) {
 	// Define the default theme for this extension.
 	// Inside your extension's activation code
 	vscode.workspace.getConfiguration('workbench')
-		.update('colorTheme', 'Stencila Light', vscode.ConfigurationTarget.Global);
+		.update('colorTheme', 'StencilaLight', vscode.ConfigurationTarget.Global);
 
 	context.subscriptions.push(disposable);
 }

--- a/themes/stencila-light-color-theme.json
+++ b/themes/stencila-light-color-theme.json
@@ -19,6 +19,7 @@
     "statusBarItem.hoverBackground": "#215DD7",
     "statusBar.debuggingBackground": "#2568EF",
     "statusBar.noFolderBackground": "#2568EF",
+    "tab.activeBorderTop": "#2568EF"
   },
   "tokenColors": [{
     "scope": [


### PR DESCRIPTION
This is to provide hooks for the writer to use so the extension is loaded by default and the default theme applied.

A previously uncommitted theme change also makes its way here.