### PR TITLE
fix: ensure that code can compile when used inside the writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode-test
 node_modules
 out
+.DS_Store
 
 # Ignore JSON file for grammer that is generated from YAML
 syntaxes/smd/tmGrammar.json

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     ],
     "iconThemes": [
       {
-        "id": "stencila",
+        "id": "StencilaIcons",
         "label": "Stencila Icons",
         "path": "./icons/stencila-icon-theme.json"
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
+		"skipLibCheck": true,
 		"strict": true   /* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */


### PR DESCRIPTION
**Description**

The writer can install and run this extension, making the provided theme the default theme & providing the rest of the extensions functionality.

Specifically this PR:

- adds `"skipLibCheck": true` to `tsconfig.ts`, so that we don't check external libraries (and in particular modules in the `writer`'s root `node_modules` directory). This was causing type check errors in external libs when compiling from within the `writer`
- updates the `IconTheme` id for the extension.

This now allows writer to access the colorTheme & iconTheme via:

`stencila.extension.editor.StencilaLight` & `stencila.extension.editor.StencilaIcons`